### PR TITLE
Disable PaperMC's PluginRemapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,14 @@
 							<shadedPattern>net.milkbowl.vault.metrics</shadedPattern>
 						</relocation>
 					</relocations>
+					<transformers>
+					        <!-- Disable PaperMC's PluginRemapper -->
+					        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+						        <manifestEntries>
+						                <paperweight-mappings-namespace>mojang</paperweight-mappings-namespace>
+						        </manifestEntries>
+				                </transformer>
+					</transformers>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Although it's not necessary, it's still annoying for non-NMS plugins. So this PR will disable that.