### PR TITLE
Add issues link (requires adding issues in GitHub repo settings)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Let me know if you need any further modifications!
 * vault.update
   - Determines if a player should receive the update notices.
 
+## Support
+- Issues: https://github.com/TheNewEconomy/VaultUnlocked/issues
+
 ## License
 Copyright (C) 2024 Daniel "creatorfromhell" Vidmar
 


### PR DESCRIPTION
- [ ] Please enable issues in GitHub repo settings (off by default for forks)

I do have an issue to report as well (not related to the PR, but I can't report it anywhere yet because of the above setting on the GitHub repo)... We want to automate updates (with clickable confirmation on our Minecraft server management software) but SpigotMC does not allow automation (but latest release(s) aren't on GitHub). Adding releases to GitHub will allow people to compile the same version as released for debugging purposes, and automate updates. If you put the plugin on Modrinth that's even better, because there you can mark which servers (Paper, Vanilla, other, as well as version range) it is compatible with so servers can auto-update if they have server management software)